### PR TITLE
Add config for Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+sphinx:
+  configuration: docs/conf.py
+formats: all
+python:
+  version: 3.8
+  install:
+    - requirements: docs/requirements.txt
+    - path: .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Tests](https://github.com/SoheilSalmani/wikipedia-cli/actions/workflows/tests.yml/badge.svg)](https://github.com/SoheilSalmani/wikipedia-cli/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/SoheilSalmani/wikipedia-cli/branch/master/graph/badge.svg?token=KG1NCKGY95)](https://codecov.io/gh/SoheilSalmani/wikipedia-cli)
 [![PyPI](https://img.shields.io/pypi/v/wikipedia-cli-by-ss)](https://pypi.org/project/wikipedia-cli-by-ss/)
+[![Documentation Status](https://readthedocs.org/projects/wikipedia-cli/badge/?version=latest)](https://wikipedia-cli.readthedocs.io/en/latest/?badge=latest)
 
 # Wikipedia CLI
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==4.2.0
+sphinx-autodoc-typehints==1.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/SoheilSalmani/wikipedia-cli"
 homepage = "https://github.com/SoheilSalmani/wikipedia-cli"
+documentation = "https://wikipedia-cli.readthedocs.io/en/latest/"
 keywords = ["wikipedia", "cli"]
 packages = [
     { include = "wikipedia_cli", from = "src" }


### PR DESCRIPTION
Configure the `.readthedocs.yml` file to instruct Read the Docs how to build the project documentation.